### PR TITLE
Travis link check: ignore 429 errors and Scopus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 
 script:
 - bundle exec jekyll build
-- htmlproofer _site --alt-ignore '/assets/images/header.jpg' --http-status-ignore "401"
+- htmlproofer _site --alt-ignore '/assets/images/header.jpg' --http-status-ignore "401,429" --url-ignore "/scopus.com/"
 
 notifications:
   email:


### PR DESCRIPTION
- Ignore 429 errors because of rate limiting by Github, which causes
  spurious errors.
- Also ignore Scopus.com links because they return spurious errors
  when checked using htmlproofer