### PR TITLE
iCommands information: copy edit and expand

### DIFF
--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -27,7 +27,7 @@ getting-started:
     url: /getting-started/yoda-disk-macos.html
   - page: Connecting to the Yoda Network Disk on Linux
     url: /getting-started/yoda-disk-linux.html
-  - page: Using the iRODS icommands
+  - page: Getting started with the iRODS iCommands
     url: /getting-started/icommands.html
 
 functions:

--- a/getting-started/icommands.md
+++ b/getting-started/icommands.md
@@ -1,19 +1,53 @@
-# Getting started with iRODS icommands
+# Getting started with the iRODS iCommands
 
 Since Yoda is based on [iRODS technology](https://irods.org), it is possible to transfer
-data to and from Yoda using the iRODS communication protocol. 
-This protocol supports very efficient transfer of large data files.
+data to and from Yoda using the iRODS communication protocol. This protocol can be used
+to transfer large amounts of data in an efficient way.
 
-Researchers and data managers who are familiar with using command line tools can optionally use the [iRODS icommands tools](https://docs.irods.org/master/icommands/user/).
-Linux packages for these tools are available from [the iRODS package repository](https://packages.irods.org/).
-After configuring your package manager to use the iRODS package repository, you will be able to install the _irods-icommands_ package.
+You will need to install client software that supports the iRODS protocol on your PC.
+This page explains how to install and configure the iRODS iCommands. These
+[command line tools](https://en.wikipedia.org/wiki/Command-line_interface) are the standard
+implementation of an iRODS protocol client.
+
+## Installing iRODS iCommands
+
+Native iRODS iCommands packages are available for CentOS and Ubuntu.
+
+Windows 10 users can run the iCommands in the [the Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/about).
+MacOS users can run the commands inside a Linux VM.
+
+### Installing iCommands on CentOS
+
+iRODS currently supports CentOS 7. As of November 2019, CentOS 8 is not supported yet.
+
+Use these commands to install the iCommands package on CentOS 7:
+
+```
+sudo yum -y install wget epel-release
+sudo rpm --import https://packages.irods.org/irods-signing-key.asc
+wget -qO - https://packages.irods.org/renci-irods.yum.repo | sudo tee /etc/yum.repos.d/renci-irods.yum.repo
+sudo yum -y install irods-icommands
+```
+
+### Installing iCommands on Ubuntu
+
+iRODS currently supports Ubuntu 16.04 LTS officially. Although Ubuntu 18.04 LTS is not supported officially,
+as of November 2019, the iCommands work fine on this distribution.
+
+Use these commands to install the iCommands package on Ubuntu 16.04 LTS or Ubuntu 18.04 LTS:
+
+```
+wget -qO - https://packages.irods.org/irods-signing-key.asc | sudo apt-key add -
+echo "deb [arch=amd64] https://packages.irods.org/apt/ xenial main" | sudo tee /etc/apt/sources.list.d/renci-irods.list
+sudo apt-get update
+sudo apt -y install irods-icommands
+```
 
 ## Configuration
-The icommands tools require configuration parameters.  
-These parameters are usually stored in a configuration file
-named _~/.irods/irods\_environment.json_.
 
-Please find the configuration per environment below:
+The iCommands need to be configured to connect to the right Yoda environment.
+
+Please find the configuration for each environment below:
 
 | Environment          | Configuration | Remarks                  |
 |:-------------------- |:------------|:-------------------------|
@@ -29,8 +63,11 @@ Please find the configuration per environment below:
 | University Corporate Offices    | [Configuration](#university-corporate-offices) | |
 
 ### Dynamics of Youth
-Please cut and paste the below json information into your configuration file.
-You will only need to change the example username to your Yoda username.
+Please copy and paste this configuration into your
+_~/.irods/irods\_environment.json_ configuration file.
+
+You will need to change the example user name to your Yoda user name.
+
 ```
 {
     "irods_host": "youth.data.uu.nl",
@@ -44,8 +81,11 @@ You will only need to change the example username to your Yoda username.
 
 ### Faculty of Geosciences
 
-Please cut and paste the below json information into your configuration file.
-You will only need to change the example username to your Yoda username.
+Please copy and paste this configuration into your
+_~/.irods/irods\_environment.json_ configuration file.
+
+You will need to change the example user name to your Yoda user name.
+
 ```
 {
     "irods_host": "geo.data.uu.nl",
@@ -59,8 +99,11 @@ You will only need to change the example username to your Yoda username.
 
 ### Faculty of Humanities
 
-Please cut and paste the below json information into your configuration file.
-You will only need to change the example username to your Yoda username.
+Please copy and paste this configuration into your
+_~/.irods/irods\_environment.json_ configuration file.
+
+You will need to change the example user name to your Yoda user name.
+
 ```
 {
     "irods_host": "gw.data.uu.nl",
@@ -74,8 +117,11 @@ You will only need to change the example username to your Yoda username.
 
 ### Faculty of Law, Economics and Governance
 
-Please cut and paste the below json information into your configuration file.
-You will only need to change the example username to your Yoda username.
+Please copy and paste this configuration into your
+_~/.irods/irods\_environment.json_ configuration file.
+
+You will need to change the example user name to your Yoda user name.
+
 ```
 {
     "irods_host": "i-lab.data.uu.nl",
@@ -89,8 +135,10 @@ You will only need to change the example username to your Yoda username.
 
 ### Faculty of Medicine
 
-Please cut and paste the below json information into your configuration file.
-You will only need to change the example username to your Yoda username.
+Please copy and paste this configuration into your
+_~/.irods/irods\_environment.json_ configuration file.
+
+You will need to change the example user name to your Yoda user name.
 ```
 {
     "irods_host": "dgk.data.uu.nl",
@@ -105,8 +153,11 @@ Note that in the future we plan to change the default resource to _irodsResc_.
 
 ### Faculty of Science
 
-Please cut and paste the below json information into your configuration file.
-You will only need to change the example username to your Yoda username.
+Please copy and paste this configuration into your
+_~/.irods/irods\_environment.json_ configuration file.
+
+You will need to change the example user name to your Yoda user name.
+
 ```
 {
     "irods_host": "science.data.uu.nl",
@@ -120,8 +171,11 @@ You will only need to change the example username to your Yoda username.
 
 ### Faculty of Social and Behavioural Sciences
 
-Please cut and paste the below json information into your configuration file.
-You will only need to change the example username to your Yoda username.
+Please copy and paste this configuration into your
+_~/.irods/irods\_environment.json_ configuration file.
+
+You will need to change the example user name to your Yoda user name.
+
 ```
 {
     "irods_host": "fsw.data.uu.nl",
@@ -135,8 +189,11 @@ You will only need to change the example username to your Yoda username.
 
 ### Faculty of Veterinary Medicine
 
-Please cut and paste the below json information into your configuration file.
-You will only need to change the example username to your Yoda username.
+Please copy and paste this configuration into your
+_~/.irods/irods\_environment.json_ configuration file.
+
+You will need to change the example user name to your Yoda user name.
+
 ```
 {
     "irods_host": "dgk.data.uu.nl",
@@ -147,12 +204,16 @@ You will only need to change the example username to your Yoda username.
     "irods_authentication_scheme": "pam"
 }
 ```
+
 Note that in the future we plan to change the default resource to _irodsResc_.
 
 ### Institutions for Open Societies
 
-Please cut and paste the below json information into your configuration file.
-You will only need to change the example username to your Yoda username.
+Please copy and paste this configuration into your
+_~/.irods/irods\_environment.json_ configuration file.
+
+You will need to change the example user name to your Yoda user name.
+
 ```
 {
     "irods_host": "i-lab.data.uu.nl",
@@ -166,8 +227,11 @@ You will only need to change the example username to your Yoda username.
 
 ### University Corporate Offices
 
-Please cut and paste the below json information into your configuration file.
-You will only need to change the example username to your Yoda username.
+Please copy and paste this configuration into your
+_~/.irods/irods\_environment.json_ configuration file.
+
+You will need to change the example user name to your Yoda user name.
+
 ```
 {
     "irods_host": "its.data.uu.nl",
@@ -178,3 +242,12 @@ You will only need to change the example username to your Yoda username.
     "irods_authentication_scheme": "pam"
 }
 ```
+
+## Getting started with using the iCommands
+
+After installing and configuring the iCommands, you should be able to log in
+on the Yoda environment using the [iinit command](https://docs.irods.org/master/icommands/user/#iinit).
+
+Sections 5.3, 5.4 and 5.5 of the [iRODS beginner training](https://irods.org/uploads/2016/06/irods_beginner_training_2016.pdf)
+contain some examples of how to use the iCommands to transfer and manage files. [The iCommands manual](https://docs.irods.org/master/icommands/user/)
+has additional information.


### PR DESCRIPTION
- Add information about how to install iCommands, since we received some feedback from end users that information was unclear / too concise.
- Add pointer to examples of how to use iCommands in the beginner training.
- Misc. copy editing